### PR TITLE
fix: correct order for damage scales

### DIFF
--- a/templates/partials/DamageExpressions.hbs
+++ b/templates/partials/DamageExpressions.hbs
@@ -1,8 +1,8 @@
 <option value="0"></option>
 <option value="1">1</option>
 <option value="1d3">d3</option>
-<option value="1d6">d6</option>
 <option value="2d6kl1">d6L</option>
+<option value="1d6">d6</option>
 <option value="2d6kh1">d6H</option>
 <option value="3d6kl2">2d6L</option>
 <option value="2d6">2d6</option>

--- a/templates/roll/EWDamageRoll.hbs
+++ b/templates/roll/EWDamageRoll.hbs
@@ -14,7 +14,7 @@
                 <td id="wimg" style="width:40px;" data-wpn-img="{{wimg}}"><img src="{{wimg}}" height="32" width="32"></td>
                 <td id="wname" style="text-align:left"><span style="font-size:1.5em" data-wpn-name="{{wname}}">{{wname}}</span> {{#if (ne range 0)}}<br><span style="font-size:1.1em">(Range {{range}})</span>{{/if}}</td>
                 <td id="dmg" style="text-align:center; font-size:1.5em;">{{localize baseExpr}}
-                    
+
                     {{#if (ne attName "none")}} + {{#if half}} &#189;{{/if}} {{attName}}{{/if}}
                 </td>
             </tr>
@@ -35,8 +35,8 @@
                         <option value="0"></option>
                         <option value="1">1</option>
                         <option value="1d3">d3</option>
-                        <option value="1d6">d6</option>
                         <option value="2d6kl1">d6L</option>
+                        <option value="1d6">d6</option>
                         <option value="2d6kh1">d6H</option>
                         <option value="3d6kl2">2d6L</option>
                         <option value="2d6">2d6</option>
@@ -54,7 +54,7 @@
                  </td>
              </tr>
              <tr>
-         </table>         
+         </table>
      </div>
  </div>
 


### PR DESCRIPTION
Fixed the order of damage options. See p.51 (the damage level track, not the damage notation)