### PR TITLE
fixes biography not working initially

### DIFF
--- a/templates/actor/charactersheet.hbs
+++ b/templates/actor/charactersheet.hbs
@@ -118,9 +118,7 @@
                 </div>
                 <div class="ewhen flexrow">
                     <div class="ewhen flex-item edit-cont">
-                        <h3 class="traitsheet-header"><div>{{localize "EW.game_term.biography"}} / {{localize "EW.game_term.notes"}}</div>
-                    </h3>
-                    {{editor content=data.backstory target="data.backstory" button=true owner=owner editable=editable}}
+                        {{editor content=data.backstory target="data.backstory" button=true owner=owner editable="editable"}}
                     </div>
                 </div>
 


### PR DESCRIPTION
Without this the biography is not editable initially. You have to close the character sheet and reopen the panel.